### PR TITLE
Add shorter one liner

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -113,22 +113,12 @@ const Home: NextPage = () => {
           <h1 className="text-lg">Useful links | Docs</h1>
           <ul className="list-disc list-outside pl-4">
             <li className="my-4">
-              <a
-                href="https://docs.rocketpool.net/guides/node/local/hardware"
-                className="link"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href="https://docs.rocketpool.net/guides/node/local/hardware" className="link">
                 On how to select hardware
               </a>
             </li>
             <li className="my-4">
-              <a
-                href="https://gist.github.com/yorickdowne/f3a3e79a573bf35767cd002cc977b038"
-                className="link"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href="https://gist.github.com/yorickdowne/f3a3e79a573bf35767cd002cc977b038" className="link">
                 All about how to buy the correct drive
               </a>
             </li>

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -113,12 +113,22 @@ const Home: NextPage = () => {
           <h1 className="text-lg">Useful links | Docs</h1>
           <ul className="list-disc list-outside pl-4">
             <li className="my-4">
-              <a href="https://docs.rocketpool.net/guides/node/local/hardware" className="link">
+              <a
+                href="https://docs.rocketpool.net/guides/node/local/hardware"
+                className="link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 On how to select hardware
               </a>
             </li>
             <li className="my-4">
-              <a href="https://gist.github.com/yorickdowne/f3a3e79a573bf35767cd002cc977b038" className="link">
+              <a
+                href="https://gist.github.com/yorickdowne/f3a3e79a573bf35767cd002cc977b038"
+                className="link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 All about how to buy the correct drive
               </a>
             </li>

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -35,16 +35,14 @@ const Home: NextPage = () => {
   return (
     <div className="container mx-auto">
       {/* First row */}
-      <div className="flex flex-row flex-wrap lg:flex-nowrap lg:border-x-[1px] lg:border-y-[1px] border-black">
+      <div className="flex flex-col lg:flex-row lg:border-x-[1px] lg:border-y-[1px] border-black">
         {/* Introduction section */}
-        <section className="bg-[#df57c4] p-6 lg:p-10 lg:w-[45vw] border-x-[1px] border-y-[1px] border-black lg:border-none overflow-auto">
+        <section className="bg-[#df57c4] p-6 lg:p-10 w-full lg:w-[45vw] border-x-[1px] border-y-[1px] border-black lg:border-none overflow-auto">
           <div className="flex flex-col">
             <p className="mt-0">Run an Ethereum node with a single command:</p>
             <p className="mt-0">Mac/linux</p>
             <div className="bg-black p-2 lg:p-4 text-white text-sm overflow-auto">
-              <p className="m-2">
-                /bin/bash -c &quot;$(curl -fsSL https://client.buidlguidl.com/runBuidlGuidlClient.sh)&quot;
-              </p>
+              <p className="m-2">/bin/bash -c &quot;$(curl -fsSL https://bgclient.io)&quot;</p>
             </div>
             <p> or run the client from the repo:</p>
             <div className="bg-black p-2 lg:p-4 text-white text-sm overflow-auto">
@@ -56,15 +54,18 @@ const Home: NextPage = () => {
           </div>
         </section>
 
-        {/* Screenshot section */}
-        <section className="bg-[#DDDDDD] flex-1 p-6 flex justify-center border-x-[1px] border-b-[1px] border-black lg:border-b-0">
-          <Image src="/screenshot-2.png" alt="screenshot" className="object-contain" width={972} height={875} />
-        </section>
+        {/* Second row for mobile - flex row to make sections share the row */}
+        <div className="flex flex-row flex-1">
+          {/* Screenshot section */}
+          <section className="bg-[#DDDDDD] w-7/12 lg:flex-1 p-6 flex justify-center border-x-[1px] border-b-[1px] border-black lg:border-b-0">
+            <Image src="/screenshot-2.png" alt="screenshot" className="object-contain" width={972} height={875} />
+          </section>
 
-        {/* Satellite section */}
-        <section className="bg-[#20F658] p-6 w-[40vw] lg:flex-1 flex justify-center border-r-[1px] border-b-[1px] border-black lg:border-r-0 lg:border-b-0">
-          <Image src="/satellite-10fps.gif" alt="satellite" className="object-contain" width={436} height={535} />
-        </section>
+          {/* Satellite section */}
+          <section className="bg-[#20F658] p-6 w-5/12 lg:flex-1 flex justify-center border-r-[1px] border-b-[1px] border-black lg:border-r-0 lg:border-l-0 lg:border-b-0">
+            <Image src="/satellite-10fps.gif" alt="satellite" className="object-contain" width={436} height={535} />
+          </section>
+        </div>
       </div>
 
       {/* Second row */}

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -84,6 +84,9 @@ module.exports = {
         "pulse-fast": "pulse 1.5s cubic-bezier(.57,.21,.69,1.25) infinite",
         "animate-ping": "ping 1s ease-in-out infinite",
       },
+      screens: {
+        lg: "1145px",
+      },
     },
   },
 };


### PR DESCRIPTION
## Description

Updated one liner to use shorter link (/bin/bash -c "$(curl -fsSL https://bgclient.io)"). Fixed the top pink section so it spans entire row when screen is in medium breakpoint. Made the large breakpoint 1145 px so one liner doesn't ever wrap

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
