### PR TITLE
Fix header removing fixed logo

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -9,8 +9,8 @@ import Image from "next/image";
  */
 export const Header = () => {
   return (
-    <header className="container mx-auto pb-24 md:pb-32 lg:pb-36 border-l border-r border-black">
-      <div className="fixed container z-10 mix-blend-difference p-6 lg:p-8">
+    <header className="container mx-auto border-l border-r border-black">
+      <div className="container z-10 mix-blend-difference p-6 lg:p-8">
         <Image className="w-40 md:w-auto invert" src="client-logo.svg" alt="logo" width={260} height={78} />
       </div>
       {/* <div className="fixed container z-10 p-6 lg:p-8 flex justify-end">


### PR DESCRIPTION
There is a bug in the header logo. 

This is what is happening now when the user scrolls down:

![client buidlguidl com_ (1)](https://github.com/user-attachments/assets/2a7ebeb4-15cf-4a69-9a35-9d00dc7c670b)

I think it's a bug introduced here https://github.com/BuidlGuidl/nodes/pull/9

Fixed removing the fixed position for the image logo.

Another approach can be to have a position fixed for the whole header element.

